### PR TITLE
Do not export CSS as string when output is set to a file path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,15 @@ If you specify `true`, the plugin will insert compiled CSS into `<head/>` tag.
 ### output
 
 + Default: `rollup.build.css`
-
-+ Type: `String|Function`
++ Type: `Boolean|String|Function`
 
 If you specify a string, it will be the path to write the generated CSS.
 If you specify a function, call it passing the generated CSS as an argument.
+If you specify `true`, importing styles results in JS modules (e.g. `import cssString from './style.less'`) -- always implicitly true when the `insert` option is enabled.
 
 ### include
 
 + Default: `[ '**/*.less', '**/*.css' ]`
-
 + Type: `String|Array`
 
 Minimatch pattern or array of minimatch patterns to determine which files are transpiled by the plugin.
@@ -53,7 +52,6 @@ Minimatch pattern or array of minimatch patterns to determine which files are tr
 ### exclude
 
 + Default: `node_modules/**`
-
 + Type: `String|Array`
 
 Minimatch pattern or array of minimatch patterns to determine which files are explicitly not transpiled by the plugin, overrules the `include` option.

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,9 @@ export default function plugin (options = {insert: false}) {
                 options.option = options.option || {};
                 options.option['filename'] = id;
                 options.output = options.output || 'rollup.build.css';
-                
+
                 let css = await renderSync(code, options.option);
-                
+
                 if(options.output&&isFunc(options.output)){
                     css = await options.output(css, id);
                 }
@@ -52,9 +52,9 @@ export default function plugin (options = {insert: false}) {
 
                 let exportCode = '';
 
-                if(options.insert!=false){
+                if (options.insert!==false) {
                     exportCode = `export default ${injectFnName}(${JSON.stringify(css.toString())});`;
-                }else{
+                } else if (options.output===true) {
                     exportCode = `export default ${JSON.stringify(css.toString())};`;
                 }
                 return {


### PR DESCRIPTION
Adds the possibility to set `export` to `true` when it is desired to export the generated CSS as string. This is mostly undesirable because most users will extract all the styles to a single css bundle file. Currently the JS bundle blows up in size because it always includes all the CSS styles no matter which options are set.