### PR TITLE
Fix insert default value. 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ let renderSync = (code, option) => {
 
 let fileCount = 0;
 
-export default function plugin (options = {insert: false}) {
+export default function plugin (options = {}) {
+    options.insert = options.insert || false;
     const filter = createFilter(options.include || [ '**/*.less', '**/*.css' ], options.exclude || 'node_modules/**');
 
     const injectFnName = '__$styleInject'


### PR DESCRIPTION
Previous method was ignored when `options !== undefined`. Sorry for the broken previous attempt. Wanted to implement tests, but the mocha toolchain does not seem to be there yet? Current test fails for me.
